### PR TITLE
Remove all traces of "git lfs".

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-*.csv filter=lfs diff=lfs merge=lfs -text
-*.json filter=lfs diff=lfs merge=lfs -text
-*.gif filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Note: Even if we migrated away, if you have git-lfs installed, it will
still attempt to run git lfs after cloning. That results in an error (quota exceeded):

```
git clone https://github.com/whotracksme/whotracks.me.git
...
Error downloading object: static/img/blog/autoconsent/cookie-blocker-after.gif (ddba742): Smudge error: Error downloading static/img/blog/autoconsent/cookie-blocker-after.gif (ddba742eb728b4cd59fbd5b1ca7f136f68b9d5f298511cc96e238275f0c545da): batch response: This repository is over its data quota. Account responsible for LFS bandwidth should purchase more data packs to restore access.

Errors logged to /whotracks.me/.git/lfs/logs/20211130T165929.516695513.log
Use `git lfs logs last` to view the log.
error: external filter 'git-lfs filter-process' failed
fatal: static/img/blog/autoconsent/cookie-blocker-after.gif: smudge filter lfs failed
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry with 'git restore --source=HEAD :/'
```