### PR TITLE
Make creating directories more robust

### DIFF
--- a/whotracksme/website/build/data.py
+++ b/whotracksme/website/build/data.py
@@ -38,10 +38,8 @@ def build_api(data):
     data_dir = Path('_site/data/trackers/global')
     gh_data_dir = Path('_site/data/trackers/ghostery')
 
-    if not data_dir.exists():
-        data_dir.mkdir(parents=True)
-    if not gh_data_dir.exists():
-        gh_data_dir.mkdir(parents=True)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    gh_data_dir.mkdir(parents=True, exist_ok=True)
 
     for id, stats in data.trackers.iter():
         build_tracker_json(id, data)
@@ -51,9 +49,7 @@ def build_api(data):
 def build_tracker_api_batch(batch):
     with DataSource(populate=False) as data:
         gh_data_dir = Path('_site/data/trackers/ghostery')
-
-        if not gh_data_dir.exists():
-            gh_data_dir.mkdir(parents=True)
+        gh_data_dir.mkdir(parents=True, exist_ok=True)
 
         for tracker_id in batch:
             build_tracker_json(tracker_id, data)


### PR DESCRIPTION
Make it less likely that multiple processes fail to create directories, which can sometimes break tests or builds.

(The option came in Python >=3.5. At least, it seems to be intended to be race-free: https://bugs.python.org/issue21082)

Closes #259