### PR TITLE
Redirect blogs to the Ghostery homepage

### DIFF
--- a/blog/what_is_a_tracker.md
+++ b/blog/what_is_a_tracker.md
@@ -7,6 +7,7 @@ publish: True
 date: 2017-07-22
 tags: primer, tracking
 header_img: blog/blog-trackers.jpg
+redirect_url: https://www.ghostery.com/blog/what-are-trackers
 +++
 
 

--- a/templates/blog-page.html
+++ b/templates/blog-page.html
@@ -2,6 +2,11 @@
 {% block title %}
     <title>Blog | {{blog_post.title}}</title>
     <meta name="description" content="{{ blog_post.description }}">
+
+    {% if blog_post.redirect_url %}
+        <meta http-equiv="refresh" content="0; url={{ blog_post.redirect_url }}">
+        <link rel="canonical" href="{{ blog_post.redirect_url }}" />
+    {% endif %}
 {% endblock %}
 
 {% block og_params %}

--- a/whotracksme/website/build/blog.py
+++ b/whotracksme/website/build/blog.py
@@ -17,6 +17,7 @@ META_TAGS = [
     "date",
     "tags",
     "header_img",
+    "redirect_url",
 ]
 
 def parse_blogpost(filepath):
@@ -39,9 +40,14 @@ def parse_blogpost(filepath):
             print(f'WARN: {filepath}: "description" not defined; falling back to "subtitle")')
             meta["description"] = meta.get("subtitle", "")
 
+        filename = filepath.split("/")[-1].replace(".md", "")
+        # Note: uncomment to redirect all blogs by their filename
+        # if "redirect_url" not in meta:
+        #     meta["redirect_url"] = f'https://www.ghostery.com/blog/{filename}'
         return {
-            "filename": filepath.split("/")[-1].replace(".md", ""),
+            "filename": filename,
             "title": meta["title"],
+            "redirect_url": meta.get("redirect_url", ""),
             "subtitle": meta.get("subtitle", ""),
             "description": meta.get("description", ""),
             "author": meta.get("author", "").capitalize(),


### PR DESCRIPTION
New "redirect_url" meta tag that allows to redirect blog post.

Shows an example to redirect an individual blog. Also, how to redirect all by default (currently disabled).