### PR TITLE
added simplejson, changed async-timeout version because of aiohttp is…

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 aiofiles==0.8.0
 aiohttp==3.9.2
-async-timeout==3.0.1
+async-timeout==4.0.3
 attrs==20.2.0
 bleach==3.3.0
 boto3==1.17.86
@@ -62,6 +62,7 @@ rfc3986==1.4.0
 s3transfer==0.4.2
 sanic==21.6.1
 SecretStorage==3.1.2
+simplejson==3.19.2
 six==1.15.0
 sniffio==1.1.0
 squarify==0.4.3


### PR DESCRIPTION
Fixed:

```
Traceback (most recent call last):
  File "/home/user/.local/bin/whotracksme", line 5, in <module>
    from whotracksme.main import main
  File "/home/user/.local/lib/python3.11/site-packages/whotracksme/main.py", line 29, in <module>
    from whotracksme.qa.todo import upgrade_to_https, create_task_files
  File "/home/user/.local/lib/python3.11/site-packages/whotracksme/qa/todo.py", line 2, in <module>
    from whotracksme.qa.utils import retrieve_status, write_to_file
  File "/home/user/.local/lib/python3.11/site-packages/whotracksme/qa/utils.py", line 1, in <module>
    import aiohttp
  File "/home/user/.local/lib/python3.11/site-packages/aiohttp/__init__.py", line 6, in <module>
    from .client import (
  File "/home/user/.local/lib/python3.11/site-packages/aiohttp/client.py", line 36, in <module>
    from . import hdrs, http, payload
  File "/home/user/.local/lib/python3.11/site-packages/aiohttp/http.py", line 7, in <module>
    from .http_parser import (
  File "/home/user/.local/lib/python3.11/site-packages/aiohttp/http_parser.py", line 31, in <module>
    from .helpers import DEBUG, NO_EXTENSIONS, BaseTimerContext
  File "/home/user/.local/lib/python3.11/site-packages/aiohttp/helpers.py", line 736, in <module>
    def ceil_timeout(delay: Optional[float]) -> async_timeout.Timeout:
                                                ^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'async_timeout' has no attribute 'Timeout'. Did you mean: 'timeout'?
```

```
Traceback (most recent call last):
  File "/home/user/.local/bin/whotracksme", line 5, in <module>
    from whotracksme.main import main
  File "/home/user/.local/lib/python3.11/site-packages/whotracksme/main.py", line 26, in <module>
    from whotracksme.website.builder import Builder
  File "/home/user/.local/lib/python3.11/site-packages/whotracksme/website/builder.py", line 11, in <module>
    from whotracksme.website.build.home import build_home, build_privacy_policy, build_imprint
  File "/home/user/.local/lib/python3.11/site-packages/whotracksme/website/build/home.py", line 4, in <module>
    from whotracksme.website.build.companies import company_reach
  File "/home/user/.local/lib/python3.11/site-packages/whotracksme/website/build/companies.py", line 5, in <module>
    from whotracksme.website.utils import print_progress, write_json
  File "/home/user/.local/lib/python3.11/site-packages/whotracksme/website/utils.py", line 2, in <module>
    import simplejson
ModuleNotFoundError: No module named 'simplejson'
```