### PR TITLE
API: New field called "unique_activities"

### DIFF
--- a/whotracksme/website/utils.py
+++ b/whotracksme/website/utils.py
@@ -3,18 +3,21 @@ import simplejson
 import pathlib
 import os
 
+
 def write_json(path, **data):
     def myconverter(o):
         if isinstance(o, datetime.datetime):
             return o.isoformat()
 
     pathlib.Path(os.path.dirname(path)).mkdir(parents=True, exist_ok=True)
-    json = simplejson.dumps(data, indent=2, default = myconverter)
-    with open(path, "w") as file:
+    json = simplejson.dumps(data, indent=2, default=myconverter)
+    with open(path, "w", encoding="utf-8") as file:
         file.write(json)
+
 
 def without_keys(d, keys):
     return {k: d[k] for k in d.keys() - keys}
+
 
 def print_progress(text, default_space=40):
     print("{} {:{}} done".format(text, "." * (default_space - len(text)), default_space - len(text)))


### PR DESCRIPTION
New field called "unique_activities", containing the number of unique trackers on a site. (The information already existed, but the consumer of the API had to aggregate over all websites.)

Generated file _site/api/v2/websites.json:

```
{
  "website_list": [
    {
      "id": "google.com",
      "month": "2024-02",
      "country": "global",
      "site": "google.com",
      "category": "Reference",
      "popularity": 1.0,
      "cookies": 0.2614883438987361,
      "bad_qs": 0.0021400143675326,
      "tracked": 0.2618860934854348,
      "https": 0.999136130843576,
      "requests": 101.61207991402377,
      "requests_tracking": 3.846237591998417,
      "content_length": 2162783.0742494627,
      "requests_failed": 12.757976695299664,
      "has_blocking": 0.2408067546853555,
      "script": 0.9387207838913364,
      "iframe": 0.2110396210803613,
      "beacon": 0.0353643639954989,
      "image": 0.9474138635742368,
      "stylesheet": 0.7562329245231064,
      "font": 0.8410333264628067,
      "xhr": 0.3449501434836037,
      "plugin": 2.91640795679226e-05,
      "media": 0.0693859633084981,
      "referer_leaked": 0.1743231396687665,
      "referer_leaked_header": 0.1207855807188978,
      "referer_leaked_url": 0.0293009417919315,
      "hosts": 3.4214821343060327,
      "trackers": 3.130871595303494,
      "companies": 1.3093942012718274,
      "unique_activities": 14        <------- NEW
    },
...
```